### PR TITLE
Apptainer v1.1.2, Github action to build image (#5)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,22 @@
+name: Docker Image CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      APPTAINER_COMMITISH:
+        description: 'Apptainer version'
+        type: choice
+        required: true
+        default: 'v1.1.2'
+        options:
+          - 'main'
+          - 'v1.1.0'
+          - 'v1.1.2'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build --build-arg APPTAINER_COMMITISH=${{github.event.inputs.APPTAINER_COMMITISH}} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-alpine3.15 as builder
+FROM golang:1.19.1-alpine3.16 as builder
 
 RUN apk add --no-cache \
         # Required for apptainer to find min go version
@@ -16,16 +16,17 @@ RUN apk add --no-cache \
         util-linux-dev
 
 ARG APPTAINER_COMMITISH="main"
+ARG MCONFIG_OPTIONS="--with-suid"
 WORKDIR $GOPATH/src/github.com/apptainer
 RUN git clone https://github.com/apptainer/apptainer.git \
     && cd apptainer \
     && git checkout "$APPTAINER_COMMITISH" \
-    && ./mconfig -p /usr/local/apptainer \
+    && ./mconfig $MCONFIG_OPTIONS -p /usr/local/apptainer \
     && cd builddir \
     && make \
     && make install
 
-FROM alpine:3.15
+FROM alpine:3.16
 COPY --from=builder /usr/local/apptainer /usr/local/apptainer
 ENV PATH="/usr/local/apptainer/bin:$PATH" \
     APPTAINER_TMPDIR="/tmp-apptainer"

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ INFO:    Downloading shub image
 
 ## Build image
 
-Version 3.8.0
+Apptainer version 1.1.2:
 
 ```bash
-$ docker build --build-arg APPTAINER_COMMITISH=v1.0.0 -t apptainer:1.0.0 - < Dockerfile
+$ docker build --build-arg APPTAINER_COMMITISH=v1.1.2 -t apptainer:1.1.2 - < Dockerfile
 ```
 
 Bleeding-edge (main branch):


### PR DESCRIPTION
* Updated section on Build image to use apptainer version 1.1.0

* go and alpine linux updated

* Create docker-image.yml

* Update Dockerfile

* Update docker-image.yml

* Update docker-image.yml

* Examples using Apptainer version 1.1.2.

* Enable use of v1.1.2.

* Update Dockerfile

Co-authored-by: Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>

* Allow mconfig options to be supplied during build, default is --with-suid.

Co-authored-by: Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>