### PR TITLE
Apptainer 1.1.5. (#9)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,13 +7,14 @@ on:
         description: 'Apptainer version'
         type: choice
         required: true
-        default: 'v1.1.4'
+        default: 'v1.1.5'
         options:
           - 'main'
           - 'v1.1.0'
           - 'v1.1.2'
           - 'v1.1.3'
           - 'v1.1.4'
+          - 'v1.1.5'
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.1-alpine3.16 as builder
+FROM golang:1.19.4-alpine3.17 as builder
 
 RUN apk add --no-cache \
         # Required for apptainer to find min go version
@@ -26,7 +26,7 @@ RUN git clone https://github.com/apptainer/apptainer.git \
     && make \
     && make install
 
-FROM alpine:3.16
+FROM alpine:3.17
 COPY --from=builder /usr/local/apptainer /usr/local/apptainer
 ENV PATH="/usr/local/apptainer/bin:$PATH" \
     APPTAINER_TMPDIR="/tmp-apptainer"

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ INFO:    Downloading shub image
 
 ## Build image
 
-Apptainer version 1.1.4:
+Apptainer version 1.1.5:
 
 ```bash
-$ docker build --build-arg APPTAINER_COMMITISH=v1.1.4 -t apptainer:1.1.4 .
+$ docker build --build-arg APPTAINER_COMMITISH=v1.1.5 -t apptainer:1.1.5 .
 ```
 
 Bleeding-edge (main branch):


### PR DESCRIPTION
* Updated section on Build image to use apptainer version 1.1.0

* go and alpine linux updated

* Create docker-image.yml

* Update Dockerfile

* Update docker-image.yml

* Update docker-image.yml

* Examples using Apptainer version 1.1.2.

* Enable use of v1.1.2.

* Update Dockerfile

Co-authored-by: Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>

* Allow mconfig options to be supplied during build, default is --with-suid.

* Apptainer 1.1.3

* Apptainer 1.1.4.

* Apptainer 1.1.5.

Co-authored-by: Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>